### PR TITLE
Example of a Clojure program that is structurally identical to Python

### DIFF
--- a/notebooks/chapters.edn
+++ b/notebooks/chapters.edn
@@ -1,4 +1,4 @@
-[#_"walkthrough_js"
- #_"walkthrough_lua"
- #_"walkthrough_py"
+["walkthrough_js"
+ "walkthrough_lua"
+ "walkthrough_py"
  "blockly_python"]

--- a/notebooks/chapters.edn
+++ b/notebooks/chapters.edn
@@ -1,3 +1,4 @@
-["walkthrough_js"
- "walkthrough_lua"
- "walkthrough_py"]
+[#_"walkthrough_js"
+ #_"walkthrough_lua"
+ #_"walkthrough_py"
+ "blockly_python"]

--- a/notebooks/stdlang_book/blockly_python.clj
+++ b/notebooks/stdlang_book/blockly_python.clj
@@ -1,21 +1,38 @@
 (ns stdlang-book.blockly-python
+  (:refer-clojure :exclude [do])
   (:require [std.lang :as l]))
 
 ^:kindly/hide-code
 (require
- '[scicloj.kindly.v4.kind :as kind]
- '[scicloj.kindly.v4.api :as kindly])
+  '[scicloj.kindly.v4.kind :as kind]
+  '[scicloj.kindly.v4.api :as kindly])
 
-^{:kindly/hide-code true :kind/hidden true}
-(l/script+ [:code :python]
-  {:require [[xt.lang.base-lib :as k]
-             [xt.lang.base-iter :as it]]})
+^:kindly/hide-code
+(def md
+  (comp kindly/hide-code kind/md))
 
-^{:kindly/hide-code true :kind/hidden true}
-(l/script+ [:live :python]
-  {:runtime :basic
-   :require [[xt.lang.base-lib :as k]
-             [xt.lang.base-iter :as it]]})
+;; # Resembling Python Syntax
+
+;; ## Intro
+
+(md "It is of course known to Clojurians that, using Macros, one can morph Clojure's syntax to more and more resemble Python syntax. The only thing that remains after such a syntax-morphing with Macros ist the position of the parentheses - tabs, space and newline can exactly be chosen as in Python.")
+
+(md "So, it is not the point of not knowing about this morphing possibility. The point is rather the followig attitude: 'Why would I want this for my programs? I left all this behind me. Why would I go back?'")
+
+(md "The answer to those questions is: You do not want to go back. You want to stick to Clojure syntax. You do not need all this morphing business. But this is not about You. It is not about improving Your value in the job market. On the contrary, it is about giving away your competitive edge.")
+
+(md "It is about building a bridge for people who are currenty doing data anaysis in Python. Buildig a bridge for people who sometimes realize that when it comes to performance and having the choice between Python and Java, the decision will always be in favor of Java, at least in an industry or business context. Building a bridge for people who have this feeling of unease when thinking about those invisible characters that in Python are meaning parts of the syntax.")
+
+(md "So let's write Python syntax where whitespace has no meaning, and let's run all this on the JVM. Let's write code to show to others. Others who are uncertain and reluctant but ready to give something new a try but want familiarity. Let's show an example that everyone knows is easy to make and noone actually makes because for the one who can make it, it is completely useless. But it matters. At least I think so.")
+
+;; ## Code Preamble
+
+^:kind/println
+(l/script+ [:tiles-code :python])
+
+^:kind/println
+(l/script+ [:tiles-live :python]
+  {:runtime :basic})
 
 (kind/scittle
   '(.log js/console "hello"))
@@ -41,26 +58,54 @@
   (and (keyword? e) (= (namespace e) "tiles")))
 
 (defn redef-def [e]
-  (if (list? e)
+  (if (seq? e)
     (cond
       (= (first e) 'def)
       (list 'var (first (second e))
             (list 'fn (into [] (rest (second e))) (redef-def (last e))))
-      (tiles-kw? (first e)) (redef-def (second e))
-      :else (remove tiles-kw? (map redef-def e))) e))
+      (tiles-kw? (first e))
+      (redef-def (second e))
+      :else
+      (remove tiles-kw? (map redef-def e)))
+    e))
 
-(defmacro ! [o e] (list 'l/! o (redef-def e)))
+(defn infx [e]
+  (if (seq? e)
+    (cond
+      (#{'+} (second e))
+      (list :tiles/infix
+            (cons (second e)
+                  (cons (first e) (rest (rest e)))))
+      :else
+      (map infx e))
+    e))
+
+(defmacro def.tl [name & e]
+  (let [e1 (cons 'do e)
+        e2 (cons 'do (interpose :tiles/slot (map infx e)))
+        e3 (redef-def e2)]
+    (list 'def name
+          {:form         (list 'quote e1)
+           :tiles-form   (list 'quote e2)
+           :clojure-form (list 'quote e3)
+           :tiles-hiccup (tiles-render e2)
+           :python-code  (list 'l/! [:tiles-code] e3)
+           :live         (list 'l/! [:tiles-live] e3)})))
+
+;; ## The Example
+
+(def.tl some-py-function
+
+  (def (hallo x y)
+    (return (x + y)))
+  (hallo 1 2)
+
+  )
 
 ^:kind/println
-(! [:code] (do (def (hello x y) (return (:tiles/infix (+ x y))))
-               :tiles/slot
-               (hello 1 2)))
+(:python-code some-py-function)
 
 ^:kind/hiccup
-(tiles-render '(do (def (hello x y) (return (:tiles/infix (+ x y))))
-                   :tiles/slot
-                   (hello 1 2)))
+(:tiles-hiccup some-py-function)
 
-(! [:live] (do (def (hello x y) (return (:tiles/infix (+ x y))))
-               :tiles/slot
-               (hello 1 2)))
+(:live some-py-function)

--- a/notebooks/stdlang_book/blockly_python.clj
+++ b/notebooks/stdlang_book/blockly_python.clj
@@ -1,0 +1,96 @@
+(ns stdlang-book.blockly-python
+  (:require [std.lang :as l]))
+
+;; std.lang can be used in different ways:
+;; - generate code for different languages
+;; - run the code in different runtimes of those languages
+
+^:kindly/hide-code
+(require 
+ '[scicloj.kindly.v4.kind :as kind]
+ '[scicloj.kindly.v4.api :as kindly])
+
+;; To specify a way to use it, we use `l/script`. This will create a runtime
+;; for evaluation.
+
+^:kind/println
+(l/script :python
+  {:require [[xt.lang.base-lib :as k]
+             [xt.lang.base-iter :as it]]})
+
+;; It is now possible to transpile lisp forms to code:
+
+(!.py
+  (+ 1 2 3))
+
+;; If more than one environment is required, `l/script+` is a way to create an annex
+;; that 
+
+;; In For example, let us define the following two annexes, named `:code` and `:live`.
+
+;; Here we define `:code` as a way to use the transpiler
+;; to generate Python code, but not use it in any runtime.
+
+^:kind/println
+(l/script+ [:code :python]
+  {:require [[xt.lang.base-lib :as k]
+             [xt.lang.base-iter :as it]]})
+
+;; Here we define `:live` as a way to use the transpiler
+;; go generate Python code, and run it in a Node.js runtime.
+
+^:kind/println
+(l/script+ [:live :python]
+  {:runtime :basic
+   :require [[xt.lang.base-lib :as k]
+             [xt.lang.base-iter :as it]]})
+
+;; Let us now use these two ways for basic arithmetic.
+
+[ ;; No runtime, just generating code:
+ (l/! [:code] (+ 1 2))
+ ;; Generating, running in Node.js:
+ (l/! [:live] (+ 1 2))]
+
+[(l/! [:code] (do (var hello (fn [x y] (return (+ x y))))
+                  (hello 1 2)))
+ (l/! [:live] (do (var hello (fn [x y] (return (+ x y))))
+                  (hello 1 2)))]
+
+(l/! [:code] (def hu 5))
+(l/! [:code] (var hu [] 5))
+
+(def a '(do (def (hello x y) (return (:tiles/infix (+ x y))))
+            (hello 1 2)))
+
+(defn redef-def [e]
+  (if (list? e)
+    (cond
+      (= (first e) 'def)
+      (list 'var (first (second e))
+            (list 'fn (into [] (rest (second e)))
+                  (redef-def (last e))))
+      (and (keyword? (first e)) (= (namespace (first e)) "tiles"))
+      (redef-def (second e))
+      :else
+      (map redef-def e))
+    e))
+
+(defmacro ! [o e]
+  (list 'l/! o (redef-def e)))
+
+(namespace :tiles/infix)
+(keyword? :tiles/infix)
+(redef-def '(:tiles/infix (+ 1 7)))
+
+(! [:code] (do (def (hello x y) (return (:tiles/infix (+ x y))))
+               (hello 1 2)))
+(! [:live] (do (def (hello x y) (return (:tiles/infix (+ x y))))
+               (hello 1 2)))
+
+(l/! [:live]  (var hello (fn [x y] (return (+ x y)))))
+
+(l/! [:live] (do (var hello (fn [x y] (return (+ x y))))
+                 (hello 1 2)))
+
+(l/! [:live] (hello 3 4))

--- a/notebooks/stdlang_book/blockly_python.clj
+++ b/notebooks/stdlang_book/blockly_python.clj
@@ -6,16 +6,36 @@
  '[scicloj.kindly.v4.kind :as kind]
  '[scicloj.kindly.v4.api :as kindly])
 
-^:kind/println
+^{:kindly/hide-code true :kind/hidden true}
 (l/script+ [:code :python]
   {:require [[xt.lang.base-lib :as k]
              [xt.lang.base-iter :as it]]})
 
-^:kind/println
+^{:kindly/hide-code true :kind/hidden true}
 (l/script+ [:live :python]
   {:runtime :basic
    :require [[xt.lang.base-lib :as k]
              [xt.lang.base-iter :as it]]})
+
+(kind/scittle
+  '(.log js/console "hello"))
+
+(kind/hiccup
+  [:div
+   [:script {:src "https://kloimhardt.github.io/twotiles/twotiles_core.js"}]
+   [:script "var parse = scittle.core.eval_string(twotiles.parse_clj);"]
+   [:script {:src "https://unpkg.com/blockly/blockly_compressed.js"}]
+   [:script {:src "https://unpkg.com/blockly/msg/en.js"}]
+   [:script "Blockly.defineBlocksWithJsonArray(twotiles.blocks);"]])
+
+(defn tiles-render [code]
+  [:div
+   [:script (str "var xml1 = parse('" code "')")]
+   [:div {:id "blocklyDiv1", :style {:height "180px"}}]
+   [:script "var workspace1 = Blockly.inject('blocklyDiv1',
+{'toolbox': twotiles.toolbox, 'sounds': false})"]
+   [:script "const xmlDom1 = Blockly.utils.xml.textToDom(xml1)"]
+   [:script "Blockly.Xml.clearWorkspaceAndLoadFromXml(xmlDom1,workspace1)"]])
 
 (defn tiles-kw? [e]
   (and (keyword? e) (= (namespace e) "tiles")))
@@ -35,29 +55,6 @@
 (! [:code] (do (def (hello x y) (return (:tiles/infix (+ x y))))
                :tiles/slot
                (hello 1 2)))
-
-^:kindly/hide-code
-(kind/scittle
-  '(.log js/console "hello"))
-
-^:kindly/hide-code
-(kind/hiccup
-  [:div
-   [:script {:src "https://kloimhardt.github.io/twotiles/twotiles_core.js"}]
-   [:script "var parse = scittle.core.eval_string(twotiles.parse_clj);"]
-   [:script {:src "https://unpkg.com/blockly/blockly_compressed.js"}]
-   [:script {:src "https://unpkg.com/blockly/msg/en.js"}]
-   [:script "Blockly.defineBlocksWithJsonArray(twotiles.blocks);"]])
-
-^:kindly/hide-code
-(defn tiles-render [code]
-  [:div
-   [:script (str "var xml1 = parse('" code "')")]
-   [:div {:id "blocklyDiv1", :style {:height "180px"}}]
-   [:script "var workspace1 = Blockly.inject('blocklyDiv1',
-{'toolbox': twotiles.toolbox, 'sounds': false})"]
-   [:script "const xmlDom1 = Blockly.utils.xml.textToDom(xml1)"]
-   [:script "Blockly.Xml.clearWorkspaceAndLoadFromXml(xmlDom1,workspace1)"]])
 
 ^:kind/hiccup
 (tiles-render '(do (def (hello x y) (return (:tiles/infix (+ x y))))

--- a/notebooks/stdlang_book/blockly_python.clj
+++ b/notebooks/stdlang_book/blockly_python.clj
@@ -17,20 +17,23 @@
    :require [[xt.lang.base-lib :as k]
              [xt.lang.base-iter :as it]]})
 
+(defn tiles-kw? [e]
+  (and (keyword? e) (= (namespace e) "tiles")))
+
 (defn redef-def [e]
   (if (list? e)
     (cond
       (= (first e) 'def)
       (list 'var (first (second e))
             (list 'fn (into [] (rest (second e))) (redef-def (last e))))
-      (and (keyword? (first e)) (= (namespace (first e)) "tiles"))
-      (redef-def (second e))
-      :else (map redef-def e)) e))
+      (tiles-kw? (first e)) (redef-def (second e))
+      :else (remove tiles-kw? (map redef-def e))) e))
 
 (defmacro ! [o e] (list 'l/! o (redef-def e)))
 
 ^:kind/println
 (! [:code] (do (def (hello x y) (return (:tiles/infix (+ x y))))
+               :tiles/slot
                (hello 1 2)))
 
 ^:kindly/hide-code
@@ -50,7 +53,7 @@
 (defn tiles-render [code]
   [:div
    [:script (str "var xml1 = parse('" code "')")]
-   [:div {:id "blocklyDiv1", :style {:height "150px"}}]
+   [:div {:id "blocklyDiv1", :style {:height "180px"}}]
    [:script "var workspace1 = Blockly.inject('blocklyDiv1',
 {'toolbox': twotiles.toolbox, 'sounds': false})"]
    [:script "const xmlDom1 = Blockly.utils.xml.textToDom(xml1)"]
@@ -58,7 +61,9 @@
 
 ^:kind/hiccup
 (tiles-render '(do (def (hello x y) (return (:tiles/infix (+ x y))))
+                   :tiles/slot
                    (hello 1 2)))
 
 (! [:live] (do (def (hello x y) (return (:tiles/infix (+ x y))))
+               :tiles/slot
                (hello 1 2)))

--- a/notebooks/stdlang_book/blockly_python.clj
+++ b/notebooks/stdlang_book/blockly_python.clj
@@ -1,5 +1,4 @@
 (ns stdlang-book.blockly-python
-  (:refer-clojure :exclude [do])
   (:require [std.lang :as l]))
 
 ^:kindly/hide-code
@@ -11,19 +10,14 @@
 (def md
   (comp kindly/hide-code kind/md))
 
-;; # Resembling Python Syntax
+;; # Python and Clojure Syntax
 
 ;; ## Intro
+(md "That the syntax of a Clojure program can be made to resemble Python is an obvious fact to any Clojurian. It is just a matter of the right Macros. But why doing such a thing?")
 
-(md "It is of course known to Clojurians that, using Macros, one can morph Clojure's syntax to more and more resemble Python syntax. The only thing that remains after such a syntax-morphing with Macros ist the position of the parentheses - tabs, space and newline can exactly be chosen as in Python.")
+(md "This thing is for Clojurians who want to build bridges for people currently using Python. Who want to build a bridge for those people who sometimes realise that when it came to performance, Java would win over Python. Building a bridge for people who have this feeling of unease when thinking about invisible characters in Python. People who already heard about functional programming.")
 
-(md "So, it is not the point of not knowing about this morphing possibility. The point is rather the followig attitude: 'Why would I want this for my programs? I left all this behind me. Why would I go back?'")
-
-(md "The answer to those questions is: You do not want to go back. You want to stick to Clojure syntax. You do not need all this morphing business. But this is not about You. It is not about improving Your value in the job market. On the contrary, it is about giving away your competitive edge.")
-
-(md "It is about building a bridge for people who are currenty doing data anaysis in Python. Buildig a bridge for people who sometimes realize that when it comes to performance and having the choice between Python and Java, the decision will always be in favor of Java, at least in an industry or business context. Building a bridge for people who have this feeling of unease when thinking about those invisible characters that in Python are meaning parts of the syntax.")
-
-(md "So let's write Python syntax where whitespace has no meaning, and let's run all this on the JVM. Let's write code to show to others. Others who are uncertain and reluctant but ready to give something new a try but want familiarity. Let's show an example that everyone knows is easy to make and noone actually makes because for the one who can make it, it is completely useless. But it matters. At least I think so.")
+(md "So let's write Python syntax where whitespace has no meaning, and let's run all this on the JVM. Let's write code to show to others. Others who are uncertain and reluctant but ready to try something new but still want familiarity. Let's show an example that everyone knows is easy to make and no-one actually makes because for the one who can make it, it is completely useless. But it matters. At least I think so.")
 
 ;; ## Code Preamble
 
@@ -93,7 +87,7 @@
            :live         (list 'l/! [:tiles-live] e3)})))
 
 ;; ## The Example
-
+;; We define a function in a syntax that resembles Python
 (def.tl some-py-function
 
   (def (hallo x y)
@@ -102,10 +96,13 @@
 
   )
 
+;; Indeed the generated Python code is similar
 ^:kind/println
 (:python-code some-py-function)
 
+;; The graphical representation also looks Pythonesque
 ^:kind/hiccup
 (:tiles-hiccup some-py-function)
 
+;; We check that the calculation is indeed correct
 (:live some-py-function)

--- a/notebooks/stdlang_book/blockly_python.clj
+++ b/notebooks/stdlang_book/blockly_python.clj
@@ -1,43 +1,15 @@
 (ns stdlang-book.blockly-python
   (:require [std.lang :as l]))
 
-;; std.lang can be used in different ways:
-;; - generate code for different languages
-;; - run the code in different runtimes of those languages
-
 ^:kindly/hide-code
-(require 
+(require
  '[scicloj.kindly.v4.kind :as kind]
  '[scicloj.kindly.v4.api :as kindly])
-
-;; To specify a way to use it, we use `l/script`. This will create a runtime
-;; for evaluation.
-
-^:kind/println
-(l/script :python
-  {:require [[xt.lang.base-lib :as k]
-             [xt.lang.base-iter :as it]]})
-
-;; It is now possible to transpile lisp forms to code:
-
-(!.py
-  (+ 1 2 3))
-
-;; If more than one environment is required, `l/script+` is a way to create an annex
-;; that 
-
-;; In For example, let us define the following two annexes, named `:code` and `:live`.
-
-;; Here we define `:code` as a way to use the transpiler
-;; to generate Python code, but not use it in any runtime.
 
 ^:kind/println
 (l/script+ [:code :python]
   {:require [[xt.lang.base-lib :as k]
              [xt.lang.base-iter :as it]]})
-
-;; Here we define `:live` as a way to use the transpiler
-;; go generate Python code, and run it in a Node.js runtime.
 
 ^:kind/println
 (l/script+ [:live :python]
@@ -45,52 +17,48 @@
    :require [[xt.lang.base-lib :as k]
              [xt.lang.base-iter :as it]]})
 
-;; Let us now use these two ways for basic arithmetic.
-
-[ ;; No runtime, just generating code:
- (l/! [:code] (+ 1 2))
- ;; Generating, running in Node.js:
- (l/! [:live] (+ 1 2))]
-
-[(l/! [:code] (do (var hello (fn [x y] (return (+ x y))))
-                  (hello 1 2)))
- (l/! [:live] (do (var hello (fn [x y] (return (+ x y))))
-                  (hello 1 2)))]
-
-(l/! [:code] (def hu 5))
-(l/! [:code] (var hu [] 5))
-
-(def a '(do (def (hello x y) (return (:tiles/infix (+ x y))))
-            (hello 1 2)))
-
 (defn redef-def [e]
   (if (list? e)
     (cond
       (= (first e) 'def)
       (list 'var (first (second e))
-            (list 'fn (into [] (rest (second e)))
-                  (redef-def (last e))))
+            (list 'fn (into [] (rest (second e))) (redef-def (last e))))
       (and (keyword? (first e)) (= (namespace (first e)) "tiles"))
       (redef-def (second e))
-      :else
-      (map redef-def e))
-    e))
+      :else (map redef-def e)) e))
 
-(defmacro ! [o e]
-  (list 'l/! o (redef-def e)))
+(defmacro ! [o e] (list 'l/! o (redef-def e)))
 
-(namespace :tiles/infix)
-(keyword? :tiles/infix)
-(redef-def '(:tiles/infix (+ 1 7)))
-
+^:kind/println
 (! [:code] (do (def (hello x y) (return (:tiles/infix (+ x y))))
                (hello 1 2)))
+
+^:kindly/hide-code
+(kind/scittle
+  '(.log js/console "hello"))
+
+^:kindly/hide-code
+(kind/hiccup
+  [:div
+   [:script {:src "https://kloimhardt.github.io/twotiles/twotiles_core.js"}]
+   [:script "var parse = scittle.core.eval_string(twotiles.parse_clj);"]
+   [:script {:src "https://unpkg.com/blockly/blockly_compressed.js"}]
+   [:script {:src "https://unpkg.com/blockly/msg/en.js"}]
+   [:script "Blockly.defineBlocksWithJsonArray(twotiles.blocks);"]])
+
+^:kindly/hide-code
+(defn tiles-render [code]
+  [:div
+   [:script (str "var xml1 = parse('" code "')")]
+   [:div {:id "blocklyDiv1", :style {:height "150px"}}]
+   [:script "var workspace1 = Blockly.inject('blocklyDiv1',
+{'toolbox': twotiles.toolbox, 'sounds': false})"]
+   [:script "const xmlDom1 = Blockly.utils.xml.textToDom(xml1)"]
+   [:script "Blockly.Xml.clearWorkspaceAndLoadFromXml(xmlDom1,workspace1)"]])
+
+^:kind/hiccup
+(tiles-render '(do (def (hello x y) (return (:tiles/infix (+ x y))))
+                   (hello 1 2)))
+
 (! [:live] (do (def (hello x y) (return (:tiles/infix (+ x y))))
                (hello 1 2)))
-
-(l/! [:live]  (var hello (fn [x y] (return (+ x y)))))
-
-(l/! [:live] (do (var hello (fn [x y] (return (+ x y))))
-                 (hello 1 2)))
-
-(l/! [:live] (hello 3 4))

--- a/notebooks/stdlang_book/blockly_python.clj
+++ b/notebooks/stdlang_book/blockly_python.clj
@@ -20,6 +20,7 @@
 (md "So let's write Python syntax where whitespace has no meaning, and let's run all this on the JVM. Let's write code to show to others. Others who are uncertain and reluctant but ready to try something new but still want familiarity. Let's show an example that everyone knows is easy to make and no-one actually makes because for the one who can make it, it is completely useless. But it matters. At least I think so.")
 
 ;; ## Code Preamble
+;; This section can be skipped in a first read, the main goal of this article is the example in the next section.
 
 ^:kind/println
 (l/script+ [:tiles-code :python])
@@ -39,14 +40,16 @@
    [:script {:src "https://unpkg.com/blockly/msg/en.js"}]
    [:script "Blockly.defineBlocksWithJsonArray(twotiles.blocks);"]])
 
-(defn tiles-render [code]
+(defn tiles-render [divid code]
   [:div
-   [:script (str "var xml1 = parse('" code "')")]
-   [:div {:id "blocklyDiv1", :style {:height "180px"}}]
-   [:script "var workspace1 = Blockly.inject('blocklyDiv1',
-{'toolbox': twotiles.toolbox, 'sounds': false})"]
-   [:script "const xmlDom1 = Blockly.utils.xml.textToDom(xml1)"]
-   [:script "Blockly.Xml.clearWorkspaceAndLoadFromXml(xmlDom1,workspace1)"]])
+   [:div {:id divid :style {:height "180px"}}]
+   [:script (str "Blockly.Xml.clearWorkspaceAndLoadFromXml(Blockly.utils.xml.textToDom(parse('" code "')),
+Blockly.inject('" divid "',
+{'toolbox': twotiles.toolbox,
+ 'sounds': false,
+ 'scrollbars': false,
+ 'trashcan': false}));")]
+   [:p]])
 
 (defn tiles-kw? [e]
   (and (keyword? e) (= (namespace e) "tiles")))
@@ -82,11 +85,12 @@
           {:form         (list 'quote e1)
            :tiles-form   (list 'quote e2)
            :clojure-form (list 'quote e3)
-           :tiles-hiccup (tiles-render e2)
+           :tiles-hiccup (tiles-render (str name) e2)
            :python-code  (list 'l/! [:tiles-code] e3)
            :live         (list 'l/! [:tiles-live] e3)})))
 
-;; ## The Example
+;; ## The Main Example
+
 ;; We define a function in a syntax that resembles Python
 (def.tl some-py-function
 
@@ -106,3 +110,80 @@
 
 ;; We check that the calculation is indeed correct
 (:live some-py-function)
+
+;; ## Step by Step Guide
+
+;; In Clojure we can define and call a basic function like this:
+
+(do
+  (def hello (fn [x y]
+               (+ x y)))
+  (hello 1 2))
+
+;; With `std-lang` for Python we can do the same in a similar manner
+
+(l/! [:tiles-live]
+  (do
+    (var hallo (fn [x y]
+                 (return (+ x y))))
+    (hallo 1 2)))
+
+;; The Python code for the same example looks like this:
+^{:kind/println true :kindly/hide-code true}
+(:python-code some-py-function)
+
+;; We want to transform the `std-lang` code to make it look more like Python. As we disregard the prefix/infix issue for the moment, the immediate aim is the following form:
+
+^:kindly/hide-code
+(quote
+  (def (hallo x y)
+    (return (+ x y))))
+
+;; To keep the above chosen form executable, it needs to be transformed back into a valid `std-lang` syntax
+
+(defn to-std-lang [e]
+  (cond
+    (= (first e) 'def)
+    (list 'var (first (second e))
+          (list 'fn (into [] (rest (second e))) (last e)))
+    :else
+    e))
+
+(to-std-lang
+  '(def (hallo x y)
+     (return (+ x y))))
+
+;; To make it more obvious that the new form indeed resembles Python, we'd like to get rid of the parentheses somehow.
+
+;; This can be done using the [Blockly](https://developers.google.com/blockly/guides/get-started/what-is-blockly) framework, which takes an XML-string and displays it in a graphical way.
+
+^:kind/hiccup
+[:div
+ [:script "var xml10 = '<xml><block id=\"funs-h-3-inp-10-10\" type=\"funs-h-3-inp\" x=10 y=10><field name=\"kopf\">hallo</field><value name=\"args-2\"><block id=\"num2-funs-h-3-inp-10-10\" type=\"num\"><field name=\"nummer\">1</field></block></value><value name=\"args-3\"><block id=\"num3-funs-h-3-inp-10-10\" type=\"num\"><field name=\"nummer\">2</field></block></value></block></xml>'"]
+ [:div {:id "blocklyDiv10", :style {:height "80px"}}]
+ [:script "var workspace10 = Blockly.inject('blocklyDiv10',
+{'toolbox': twotiles.toolbox, 'sounds': false})"]
+ [:script "const xmlDom10 = Blockly.utils.xml.textToDom(xml10)"]
+ [:script "Blockly.Xml.clearWorkspaceAndLoadFromXml(xmlDom10,workspace10)"]
+ [:p]]
+
+;; We use the small [twotiles](https://kloimhardt.github.io/twotiles/twotiles_core.js)-library to parse Clojure data structures and turn them into XML
+
+^:kind/hiccup
+[:div
+ [:script "var twotiles_parse = scittle.core.eval_string(twotiles.parse_clj);"]
+ [:script "var xml11 = twotiles_parse('(hallo 1 2)')"]
+ [:textarea {:id "blocklyText11" :style {:width "100%"}}]
+ [:script "document.getElementById(\"blocklyText11\").innerHTML = xml11"]]
+
+;; Putting `Blockly` and `twotiles` together leads do a graphical representation of our code that now without the parentheses is a further step towards Python resemblance.
+
+^:kind/hiccup
+(tiles-render "blocklyDiv12"
+              '(def (hallo x y)
+                 (return (:tiles/infix (+ x y)))))
+
+;;
+;; As you can see, I sneaked the infix feature of `twotiles` into the above example.
+
+;; Of course, to get back to an executable `std-lang` syntax, this infix instruction has to be removed together with the already shown transformation of `def` to `(var ... (fn ...))`. All this is done by the `def.tl` macro used in the preceding section that demonstrates the main example which has also been the main goal of this article.


### PR DESCRIPTION
This example shows something trivial and obvious: with Macros one can make Clojure syntax resemble Python. But the obvious actually needs to be shown:
![Screenshot 2025-05-09 at 11 27 34](https://github.com/user-attachments/assets/4878ec1c-475a-4d56-97ea-7ba28a6e9eb8)
